### PR TITLE
Avoid cache fallback on Github Enterprise

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -8,6 +8,7 @@ import {
   formatSize,
   getInputAsArray,
   getInputAsBoolean,
+  isGhes,
   newMinio,
   setCacheHitOutput,
 } from "./utils";
@@ -53,12 +54,16 @@ async function restoreCache() {
       core.info("Restore s3 cache failed: " + e.message);
       setCacheHitOutput(false);
       if (useFallback) {
-        core.info("Restore cache using fallback cache");
-        if (await cache.restoreCache(paths, key, restoreKeys)) {
-          setCacheHitOutput(true);
-          core.info("Fallback cache restored successfully");
+        if (isGhes()) {
+          core.warning('Cache fallback is not supported on Github Enterpise.')
         } else {
-          core.info("Fallback cache restore failed");
+          core.info("Restore cache using fallback cache");
+          if (await cache.restoreCache(paths, key, restoreKeys)) {
+            setCacheHitOutput(true);
+            core.info("Fallback cache restored successfully");
+          } else {
+            core.info("Fallback cache restore failed");
+          }
         }
       }
     }

--- a/src/save.ts
+++ b/src/save.ts
@@ -3,7 +3,7 @@ import * as utils from "@actions/cache/lib/internal/cacheUtils";
 import { createTar, listTar } from "@actions/cache/lib/internal/tar";
 import * as core from "@actions/core";
 import * as path from "path";
-import { getInputAsArray, getInputAsBoolean, newMinio } from "./utils";
+import { getInputAsArray, getInputAsBoolean, isGhes, newMinio } from "./utils";
 
 process.on("uncaughtException", (e) => core.info("warning: " + e.message));
 
@@ -41,9 +41,13 @@ async function saveCache() {
     } catch (e) {
       core.info("Save s3 cache failed: " + e.message);
       if (useFallback) {
-        core.info("Saving cache using fallback");
-        await cache.saveCache(paths, key);
-        core.info("Save cache using fallback successfully");
+        if (isGhes()) {
+          core.warning('Cache fallback is not supported on Github Enterpise.');
+        } else {
+          core.info("Saving cache using fallback");
+          await cache.saveCache(paths, key);
+          core.info("Save cache using fallback successfully");
+        }
       } else {
         core.debug("skipped fallback cache");
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,13 @@ import * as utils from "@actions/cache/lib/internal/cacheUtils";
 import * as core from "@actions/core";
 import * as minio from "minio";
 
+export function isGhes(): boolean {
+  const ghUrl = new URL(
+    process.env['GITHUB_SERVER_URL'] || 'https://github.com'
+  );
+  return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+}
+
 export function newMinio() {
   return new minio.Client({
     endPoint: core.getInput("endpoint"),


### PR DESCRIPTION
Github Enterprise does not support the routes needed to support the
cache fallback and will always fail.  Rather than requiring all consumers
to pass use-fallback as false, we should avoid the fallback when we know
it will be non-functional.

See https://github.com/actions/cache/issues/505

Fixes #8 
