### PR TITLE
fix cache-hit output when match isn't exact

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -6582,14 +6582,14 @@ function isGhes() {
     return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
 }
 exports.isGhes = isGhes;
-function newMinio() {
+function newMinio({ accessKey, secretKey, sessionToken, } = {}) {
     return new minio.Client({
         endPoint: core.getInput("endpoint"),
         port: getInputAsInt("port"),
         useSSL: !getInputAsBoolean("insecure"),
-        accessKey: core.getInput("accessKey"),
-        secretKey: core.getInput("secretKey"),
-        sessionToken: core.getInput("sessionToken"),
+        accessKey: accessKey !== null && accessKey !== void 0 ? accessKey : core.getInput("accessKey"),
+        secretKey: secretKey !== null && secretKey !== void 0 ? secretKey : core.getInput("secretKey"),
+        sessionToken: sessionToken !== null && sessionToken !== void 0 ? sessionToken : core.getInput("sessionToken"),
         region: core.getInput("region"),
     });
 }
@@ -6690,7 +6690,7 @@ function getMatchedKey() {
 }
 function isExactKeyMatch() {
     const matchedKey = getMatchedKey();
-    const inputKey = core.getInput("key", { required: true });
+    const inputKey = core.getState(state_1.State.PrimaryKey);
     const result = getMatchedKey() === inputKey;
     core.debug(`isExactKeyMatch: matchedKey=${matchedKey} inputKey=${inputKey}, result=${result}`);
     return result;
@@ -6967,6 +6967,10 @@ exports.State = void 0;
 var State;
 (function (State) {
     State["MatchedKey"] = "matched-key";
+    State["PrimaryKey"] = "primary-key";
+    State["AccessKey"] = "access-key";
+    State["SecretKey"] = "secret-key";
+    State["SessionToken"] = "session-token";
 })(State = exports.State || (exports.State = {}));
 
 
@@ -82047,6 +82051,7 @@ const utils = __importStar(__webpack_require__(15));
 const tar_1 = __webpack_require__(447);
 const core = __importStar(__webpack_require__(470));
 const path = __importStar(__webpack_require__(622));
+const state_1 = __webpack_require__(179);
 const utils_1 = __webpack_require__(163);
 process.on("uncaughtException", (e) => core.info("warning: " + e.message));
 function restoreCache() {
@@ -82058,6 +82063,11 @@ function restoreCache() {
             const paths = utils_1.getInputAsArray("path");
             const restoreKeys = utils_1.getInputAsArray("restore-keys");
             try {
+                // Inputs are re-evaluted before the post action, so we want to store the original values
+                core.saveState(state_1.State.PrimaryKey, key);
+                core.saveState(state_1.State.AccessKey, core.getInput("accessKey"));
+                core.saveState(state_1.State.SecretKey, core.getInput("secretKey"));
+                core.saveState(state_1.State.SessionToken, core.getInput("sessionToken"));
                 const mc = utils_1.newMinio();
                 const compressionMethod = yield utils.getCompressionMethod();
                 const cacheFileName = utils.getCacheFileName(compressionMethod);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -82064,7 +82064,7 @@ function restoreCache() {
                 }
                 core.info(`Cache Size: ${utils_1.formatSize(obj.size)} (${obj.size} bytes)`);
                 yield tar_1.extractTar(archivePath, compressionMethod);
-                utils_1.setCacheHitOutput(true);
+                utils_1.setCacheHitOutput(matchingKey === key);
                 core.info("Cache restored from s3 successfully");
             }
             catch (e) {
@@ -82076,8 +82076,9 @@ function restoreCache() {
                     }
                     else {
                         core.info("Restore cache using fallback cache");
-                        if (yield cache.restoreCache(paths, key, restoreKeys)) {
-                            utils_1.setCacheHitOutput(true);
+                        const fallbackMatchingKey = yield cache.restoreCache(paths, key, restoreKeys);
+                        if (fallbackMatchingKey) {
+                            utils_1.setCacheHitOutput(fallbackMatchingKey === key);
                             core.info("Fallback cache restored successfully");
                         }
                         else {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -6628,20 +6628,29 @@ function setCacheHitOutput(isCacheHit) {
     core.setOutput("cache-hit", isCacheHit.toString());
 }
 exports.setCacheHitOutput = setCacheHitOutput;
-function findObject(mc, bucket, keys, compressionMethod) {
+function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
-        core.debug("Restore keys: " + JSON.stringify(keys));
-        for (const key of keys) {
+        core.debug("Key: " + JSON.stringify(key));
+        core.debug("Restore keys: " + JSON.stringify(restoreKeys));
+        core.debug(`Finding exact macth for: ${key}`);
+        const exactMatch = yield listObjects(mc, bucket, key);
+        core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
+        if (exactMatch.length) {
+            const result = { item: exactMatch[0], matchingKey: key };
+            core.debug(`Using ${JSON.stringify(result)}`);
+            return result;
+        }
+        for (const restoreKey of restoreKeys) {
             const fn = utils.getCacheFileName(compressionMethod);
-            core.debug(`Finding object with prefix: ${key}`);
-            let objects = yield listObjects(mc, bucket, key);
+            core.debug(`Finding object with prefix: ${restoreKey}`);
+            let objects = yield listObjects(mc, bucket, restoreKey);
             objects = objects.filter((o) => o.name.includes(fn));
             core.debug(`Found ${JSON.stringify(objects, null, 2)}`);
             if (objects.length < 1) {
                 continue;
             }
             const sorted = objects.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-            const result = { item: sorted[0], matchingKey: key };
+            const result = { item: sorted[0], matchingKey: restoreKey };
             core.debug(`Using latest ${JSON.stringify(result)}`);
             return result;
         }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -50,7 +50,7 @@ async function restoreCache() {
       core.info(`Cache Size: ${formatSize(obj.size)} (${obj.size} bytes)`);
 
       await extractTar(archivePath, compressionMethod);
-      setCacheHitOutput(true);
+      setCacheHitOutput(matchingKey === key);
       core.info("Cache restored from s3 successfully");
     } catch (e) {
       core.info("Restore s3 cache failed: " + e.message);
@@ -60,8 +60,9 @@ async function restoreCache() {
           core.warning('Cache fallback is not supported on Github Enterpise.')
         } else {
           core.info("Restore cache using fallback cache");
-          if (await cache.restoreCache(paths, key, restoreKeys)) {
-            setCacheHitOutput(true);
+          const fallbackMatchingKey = await cache.restoreCache(paths, key, restoreKeys)
+          if (fallbackMatchingKey) {
+            setCacheHitOutput(fallbackMatchingKey === key);
             core.info("Fallback cache restored successfully");
           } else {
             core.info("Fallback cache restore failed");

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -3,6 +3,7 @@ import * as utils from "@actions/cache/lib/internal/cacheUtils";
 import { extractTar, listTar } from "@actions/cache/lib/internal/tar";
 import * as core from "@actions/core";
 import * as path from "path";
+import { State } from "./state";
 import {
   findObject,
   formatSize,
@@ -25,6 +26,12 @@ async function restoreCache() {
     const restoreKeys = getInputAsArray("restore-keys");
 
     try {
+      // Inputs are re-evaluted before the post action, so we want to store the original values
+      core.saveState(State.PrimaryKey, key);
+      core.saveState(State.AccessKey, core.getInput("accessKey"));
+      core.saveState(State.SecretKey, core.getInput("secretKey"));
+      core.saveState(State.SessionToken, core.getInput("sessionToken"));
+
       const mc = newMinio();
 
       const compressionMethod = await utils.getCompressionMethod();

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -33,9 +33,8 @@ async function restoreCache() {
         await utils.createTempDirectory(),
         cacheFileName
       );
-      const keys = [key, ...restoreKeys];
 
-      const { item: obj, matchingKey } = await findObject(mc, bucket, keys, compressionMethod);
+      const { item: obj, matchingKey } = await findObject(mc, bucket, key,restoreKeys, compressionMethod);
       core.debug("found cache object");
       saveMatchedKey(matchingKey);
       core.info(

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,3 +1,7 @@
 export enum State {
-    "MatchedKey" = "matched-key"
+    "MatchedKey" = "matched-key",
+    "PrimaryKey" = "primary-key",
+    "AccessKey" = "access-key",
+    "SecretKey" = "secret-key",
+    "SessionToken" = "session-token",
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -12,7 +12,8 @@ describe("utils", () => {
     const got = await findObject(
       mc,
       "actions-cache",
-      ["foo.bar", "test-Linux-"],
+      "foo.bar",
+      ["test-Linux-"],
       await getCompressionMethod()
     );
     expect(got).toBeTruthy();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,14 +77,27 @@ type FindObjectResult = {
 export async function findObject(
   mc: minio.Client,
   bucket: string,
-  keys: string[],
+  key: string,
+  restoreKeys: string[],
   compressionMethod: CompressionMethod
 ): Promise<FindObjectResult> {
-  core.debug("Restore keys: " + JSON.stringify(keys));
-  for (const key of keys) {
+  core.debug("Key: " + JSON.stringify(key));
+  core.debug("Restore keys: " + JSON.stringify(restoreKeys));
+
+  core.debug(`Finding exact macth for: ${key}`);
+  const exactMatch = await listObjects(mc, bucket, key);
+  core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
+  if (exactMatch.length) {
+    const result = { item: exactMatch[0], matchingKey: key };
+    core.debug(`Using ${JSON.stringify(result)}`);
+    return result;
+  }
+
+
+  for (const restoreKey of restoreKeys) {
     const fn = utils.getCacheFileName(compressionMethod);
-    core.debug(`Finding object with prefix: ${key}`);
-    let objects = await listObjects(mc, bucket, key);
+    core.debug(`Finding object with prefix: ${restoreKey}`);
+    let objects = await listObjects(mc, bucket, restoreKey);
     objects = objects.filter((o) => o.name.includes(fn));
     core.debug(`Found ${JSON.stringify(objects, null, 2)}`);
     if (objects.length < 1) {
@@ -93,7 +106,7 @@ export async function findObject(
     const sorted = objects.sort(
       (a, b) => b.lastModified.getTime() - a.lastModified.getTime()
     );
-    const result = { item: sorted[0], matchingKey: key };
+    const result = { item: sorted[0], matchingKey: restoreKey };
     core.debug(`Using latest ${JSON.stringify(result)}`);
     return result;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,14 +11,22 @@ export function isGhes(): boolean {
   return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
 }
 
-export function newMinio() {
+export function newMinio({
+  accessKey,
+  secretKey,
+  sessionToken,
+}: {
+  accessKey?: string,
+  secretKey?: string,
+  sessionToken?: string,
+} = {}) {
   return new minio.Client({
     endPoint: core.getInput("endpoint"),
     port: getInputAsInt("port"),
     useSSL: !getInputAsBoolean("insecure"),
-    accessKey: core.getInput("accessKey"),
-    secretKey: core.getInput("secretKey"),
-    sessionToken: core.getInput("sessionToken"),
+    accessKey: accessKey ?? core.getInput("accessKey"),
+    secretKey: secretKey ?? core.getInput("secretKey"),
+    sessionToken: sessionToken ?? core.getInput("sessionToken"),
     region: core.getInput("region"),
   });
 }
@@ -150,7 +158,7 @@ function getMatchedKey() {
 
 export function isExactKeyMatch(): boolean {
   const matchedKey = getMatchedKey();
-  const inputKey = core.getInput("key", { required: true });
+  const inputKey = core.getState(State.PrimaryKey);
   const result = getMatchedKey() === inputKey;
   core.debug(
     `isExactKeyMatch: matchedKey=${matchedKey} inputKey=${inputKey}, result=${result}`


### PR DESCRIPTION
<!-- Description of PR that completes issue here... -->

The original [actions/cache](https://github.com/actions/cache) action is setting `cache-hit` to `true` only if the cache key was **exact** match:

> restore-keys - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note cache-hit returns false in this case.

So this PR fixes the behavior and sets the `cache-hit` output to `true` just only if the cache key is **exact** match.

Also persist `key` inside state, so it's not re-evaluated in post action.
And change `restore` so it prioritizes cache matched with `key` over `restore-keys`.
