### PR TITLE
Start using Node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the primary key"
 runs:
-  using: node12
+  using: node16
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
   post-if: "success()"


### PR DESCRIPTION
We are getting this message from Github:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: tespkg/actions-cache
```

## Changes

- Updated the identifier of NodeJS in action.yml

## Fix Issues

A GitHub warning about https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
