### PR TITLE
Add an action output for cache size

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ inputs:
 outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the primary key"
+  cache-size:
+    description: "A integer value denoting the size of the cache object found (measured in bytes)"
 runs:
   using: node16
   main: "dist/restore/index.js"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -6329,7 +6329,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isExactKeyMatch = exports.saveMatchedKey = exports.listObjects = exports.findObject = exports.setCacheHitOutput = exports.formatSize = exports.getInputAsInt = exports.getInputAsArray = exports.getInputAsBoolean = exports.newMinio = exports.isGhes = void 0;
+exports.isExactKeyMatch = exports.saveMatchedKey = exports.listObjects = exports.findObject = exports.setCacheSizeOutput = exports.setCacheHitOutput = exports.formatSize = exports.getInputAsInt = exports.getInputAsArray = exports.getInputAsBoolean = exports.newMinio = exports.isGhes = void 0;
 const utils = __importStar(__webpack_require__(15));
 const core = __importStar(__webpack_require__(470));
 const minio = __importStar(__webpack_require__(223));
@@ -6385,6 +6385,10 @@ function setCacheHitOutput(isCacheHit) {
     core.setOutput("cache-hit", isCacheHit.toString());
 }
 exports.setCacheHitOutput = setCacheHitOutput;
+function setCacheSizeOutput(cacheSize) {
+    core.setOutput("cache-size", cacheSize.toString());
+}
+exports.setCacheSizeOutput = setCacheSizeOutput;
 function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Key: " + JSON.stringify(key));
@@ -84143,6 +84147,7 @@ function restoreCache() {
                 core.info(`Cache Size: ${utils_1.formatSize(obj.size)} (${obj.size} bytes)`);
                 yield tar_1.extractTar(archivePath, compressionMethod);
                 utils_1.setCacheHitOutput(matchingKey === key);
+                utils_1.setCacheSizeOutput(obj.size);
                 core.info("Cache restored from s3 successfully");
             }
             catch (e) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -6329,7 +6329,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isExactKeyMatch = exports.saveMatchedKey = exports.listObjects = exports.findObject = exports.setCacheHitOutput = exports.formatSize = exports.getInputAsInt = exports.getInputAsArray = exports.getInputAsBoolean = exports.newMinio = exports.isGhes = void 0;
+exports.isExactKeyMatch = exports.saveMatchedKey = exports.listObjects = exports.findObject = exports.setCacheSizeOutput = exports.setCacheHitOutput = exports.formatSize = exports.getInputAsInt = exports.getInputAsArray = exports.getInputAsBoolean = exports.newMinio = exports.isGhes = void 0;
 const utils = __importStar(__webpack_require__(15));
 const core = __importStar(__webpack_require__(470));
 const minio = __importStar(__webpack_require__(223));
@@ -6385,6 +6385,10 @@ function setCacheHitOutput(isCacheHit) {
     core.setOutput("cache-hit", isCacheHit.toString());
 }
 exports.setCacheHitOutput = setCacheHitOutput;
+function setCacheSizeOutput(cacheSize) {
+    core.setOutput("cache-size", cacheSize.toString());
+}
+exports.setCacheSizeOutput = setCacheSizeOutput;
 function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Key: " + JSON.stringify(key));

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -12,6 +12,7 @@ import {
   isGhes,
   newMinio,
   setCacheHitOutput,
+  setCacheSizeOutput,
   saveMatchedKey,
 } from "./utils";
 
@@ -63,6 +64,7 @@ async function restoreCache() {
 
       await extractTar(archivePath, compressionMethod);
       setCacheHitOutput(matchingKey === key);
+      setCacheSizeOutput(obj.size)
       core.info("Cache restored from s3 successfully");
     } catch (e) {
       core.info("Restore s3 cache failed: " + e.message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,10 @@ export function setCacheHitOutput(isCacheHit: boolean): void {
   core.setOutput("cache-hit", isCacheHit.toString());
 }
 
+export function setCacheSizeOutput(cacheSize: number): void {
+  core.setOutput("cache-size", cacheSize.toString())
+}
+
 type FindObjectResult = {
   item: minio.BucketItem;
   matchingKey: string;


### PR DESCRIPTION
## Changes

<!-- Example:
- Change 1
- Change 2
- Change 3 - With additional note
-->

<!-- Description of PR that completes issue here... -->

I'm seeing some cache-hits that are basically empty?

```
Cache Size: 22bytes (22 bytes)
/usr/bin/tar --use-compress-program zstd -d -xf /runner/_work/_temp/051fd982-919c-487f-bb71-d[18](https://github.com/.../actions/runs/5405282943/jobs/9821288693#step:4:19)260fde93d/cache.tzst -P -C /runner/_work/...
Cache restored from s3 successfully
```

22 bytes when something like 537680268 bytes are really expected...

This leads to a positive cache hit and the rest of my workflow continues as if the cache object has been restored when it really wasn't in the s3 bucket at all. Later in the workflow everything fails when if I had known the hit was incorrect, I could have build the asset in the workflow.

These changes add a `cache-size` output to the action so that other steps can decide if they want to trust a cache hit.



## Fix Issues

<!-- Example:
 - Fixes #85
 - Fixes #22
 - Fixes username/repo#123
 - Connects #123
-->
