### PR TITLE
SW-26574 - add lookup-only

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Use github actions/cache as fallback"
     required: false
     default: "true"
+  lookup-only:
+    description: "Check if a restore is successfull but dont download/extract cache."
+    required: false
+    default: "false"
   # zip-option:
   #   description: zip options
   #   required: false

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -109658,9 +109658,10 @@ function restoreCache() {
                 const { item: obj, matchingKey } = yield (0, utils_1.findObject)(mc, bucket, key, restoreKeys, compressionMethod);
                 core.debug("found cache object");
                 (0, utils_1.saveMatchedKey)(matchingKey);
-                if ("true" === lookupOnly) {
+                if (("true" === lookupOnly) && (matchingKey === key) && (obj.size > 0)) {
                     core.info(`Cache Hit. NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`);
-                    (0, utils_1.setCacheHitOutput)(matchingKey === key);
+                    (0, utils_1.setCacheHitOutput)(true);
+                    (0, utils_1.setCacheSizeOutput)(obj.size);
                 }
                 else {
                     core.info(`Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -109643,6 +109643,7 @@ function restoreCache() {
             const useFallback = (0, utils_1.getInputAsBoolean)("use-fallback");
             const paths = (0, utils_1.getInputAsArray)("path");
             const restoreKeys = (0, utils_1.getInputAsArray)("restore-keys");
+            const lookupOnly = core.getInput("lookup-only", { required: false });
             try {
                 // Inputs are re-evaluted before the post action, so we want to store the original values
                 core.saveState(state_1.State.PrimaryKey, key);
@@ -109657,16 +109658,22 @@ function restoreCache() {
                 const { item: obj, matchingKey } = yield (0, utils_1.findObject)(mc, bucket, key, restoreKeys, compressionMethod);
                 core.debug("found cache object");
                 (0, utils_1.saveMatchedKey)(matchingKey);
-                core.info(`Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`);
-                yield mc.fGetObject(bucket, obj.name, archivePath);
-                if (core.isDebug()) {
-                    yield (0, tar_1.listTar)(archivePath, compressionMethod);
+                if ("true" === lookupOnly) {
+                    core.info(`NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`);
+                    (0, utils_1.setCacheHitOutput)(matchingKey === key);
                 }
-                core.info(`Cache Size: ${(0, utils_1.formatSize)(obj.size)} (${obj.size} bytes)`);
-                yield (0, tar_1.extractTar)(archivePath, compressionMethod);
-                (0, utils_1.setCacheHitOutput)(matchingKey === key);
-                (0, utils_1.setCacheSizeOutput)(obj.size);
-                core.info("Cache restored from s3 successfully");
+                else {
+                    core.info(`Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`);
+                    yield mc.fGetObject(bucket, obj.name, archivePath);
+                    if (core.isDebug()) {
+                        yield (0, tar_1.listTar)(archivePath, compressionMethod);
+                    }
+                    core.info(`Cache Size: ${(0, utils_1.formatSize)(obj.size)} (${obj.size} bytes)`);
+                    yield (0, tar_1.extractTar)(archivePath, compressionMethod);
+                    (0, utils_1.setCacheHitOutput)(matchingKey === key);
+                    (0, utils_1.setCacheSizeOutput)(obj.size);
+                    core.info("Cache restored from s3 successfully");
+                }
             }
             catch (e) {
                 core.info("Restore s3 cache failed: " + e.message);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -109659,7 +109659,7 @@ function restoreCache() {
                 core.debug("found cache object");
                 (0, utils_1.saveMatchedKey)(matchingKey);
                 if ("true" === lookupOnly) {
-                    core.info(`NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`);
+                    core.info(`Cache Hit. NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`);
                     (0, utils_1.setCacheHitOutput)(matchingKey === key);
                 }
                 else {

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ const processStdoutWrite = process.stdout.write.bind(process.stdout);
 process.stdout.write = (str, encoding, cb) => {
   // Core library will directly call process.stdout.write for commands
   // We don't want :: commands to be executed by the runner during tests
-  if (!str.match(/^::/)) {
+  if (typeof str === 'string' && !str.match(/^::/)) {
     return processStdoutWrite(str, encoding, cb);
   }
 };

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Use github actions/cache as fallback"
     required: false
     default: "true"
+  lookup-only:
+    description: "Check if a restore is successfull but dont download/extract cache."
+    required: false
+    default: "false"
   # zip-option:
   #   description: zip options
   #   required: false

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -56,7 +56,7 @@ async function restoreCache() {
       saveMatchedKey(matchingKey);
       if ("true" === lookupOnly) {
         core.info(
-          `NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`
+          `Cache Hit. NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`
         );
         setCacheHitOutput(matchingKey === key);
       } else {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -26,6 +26,7 @@ async function restoreCache() {
     const useFallback = getInputAsBoolean("use-fallback");
     const paths = getInputAsArray("path");
     const restoreKeys = getInputAsArray("restore-keys");
+    const lookupOnly = core.getInput("lookup-only", { required: false });
 
     try {
       // Inputs are re-evaluted before the post action, so we want to store the original values
@@ -53,21 +54,28 @@ async function restoreCache() {
       );
       core.debug("found cache object");
       saveMatchedKey(matchingKey);
-      core.info(
-        `Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`
-      );
-      await mc.fGetObject(bucket, obj.name, archivePath);
+      if ("true" === lookupOnly) {
+        core.info(
+          `NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`
+        );
+        setCacheHitOutput(matchingKey === key);
+      } else {
+        core.info(
+          `Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`
+        );
+        await mc.fGetObject(bucket, obj.name, archivePath);
 
-      if (core.isDebug()) {
-        await listTar(archivePath, compressionMethod);
+        if (core.isDebug()) {
+          await listTar(archivePath, compressionMethod);
+        }
+
+        core.info(`Cache Size: ${formatSize(obj.size)} (${obj.size} bytes)`);
+
+        await extractTar(archivePath, compressionMethod);
+        setCacheHitOutput(matchingKey === key);
+        setCacheSizeOutput(obj.size)
+        core.info("Cache restored from s3 successfully");
       }
-
-      core.info(`Cache Size: ${formatSize(obj.size)} (${obj.size} bytes)`);
-
-      await extractTar(archivePath, compressionMethod);
-      setCacheHitOutput(matchingKey === key);
-      setCacheSizeOutput(obj.size)
-      core.info("Cache restored from s3 successfully");
     } catch (e) {
       core.info("Restore s3 cache failed: " + e.message);
       setCacheHitOutput(false);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -54,11 +54,13 @@ async function restoreCache() {
       );
       core.debug("found cache object");
       saveMatchedKey(matchingKey);
-      if ("true" === lookupOnly) {
+      if (("true" === lookupOnly) && (matchingKey === key) && (obj.size > 0)) {
         core.info(
           `Cache Hit. NOT Downloading cache from s3, lookup-only is set. bucket: ${bucket}, object: ${obj.name}`
         );
-        setCacheHitOutput(matchingKey === key);
+
+        setCacheHitOutput(true);
+        setCacheSizeOutput(obj.size);
       } else {
         core.info(
           `Downloading cache from s3 to ${archivePath}. bucket: ${bucket}, object: ${obj.name}`


### PR DESCRIPTION
SW-26574 - add lookup-only

allow during s3-gha-cache/restore to use lookup-only for faster cache verification
the output cache-hit can then be used to bypass cache preparation or prepare it due to key mismatch or cache is not accessible at s3 location. 

## Changes

new option during cache/restore: lookup-only: "true" or "false" # false is the default and downloads cache