### PR TITLE
fix: exact matching

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -109854,7 +109854,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => obj.name === key);
+            const exactMatch = keyMatches.find((obj) => obj.name.startsWith(key));
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -109769,7 +109769,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => obj.name === key);
+            const exactMatch = keyMatches.find((obj) => obj.name.startsWith(key));
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/dist/saveOnly/index.js
+++ b/dist/saveOnly/index.js
@@ -109769,7 +109769,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => obj.name === key);
+            const exactMatch = keyMatches.find((obj) => obj.name.startsWith(key));
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,17 +112,18 @@ export async function findObject(
   core.debug("Key: " + JSON.stringify(key));
   core.debug("Restore keys: " + JSON.stringify(restoreKeys));
 
-  core.debug(`Finding exact macth for: ${key}`);
+  core.debug(`Finding exact match for: ${key}`);
   const keyMatches = await listObjects(mc, bucket, key);
   core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
   if (keyMatches.length > 0) {
-    const exactMatch = keyMatches.find((obj) => obj.name === key)
+    const exactMatch = keyMatches.find((obj) => obj.name === key);
     if (exactMatch) {
       const result = { item: exactMatch, matchingKey: key };
-      core.debug(`Using ${JSON.stringify(result)}`);
+      core.debug(`Found an exact match; using ${JSON.stringify(result)}`);
       return result;
     }
   }
+  core.debug(`Didn't find an exact match`);
 
   for (const restoreKey of restoreKeys) {
     const fn = utils.getCacheFileName(compressionMethod);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,12 +113,15 @@ export async function findObject(
   core.debug("Restore keys: " + JSON.stringify(restoreKeys));
 
   core.debug(`Finding exact macth for: ${key}`);
-  const exactMatch = await listObjects(mc, bucket, key);
-  core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
-  if (exactMatch.length) {
-    const result = { item: exactMatch[0], matchingKey: key };
-    core.debug(`Using ${JSON.stringify(result)}`);
-    return result;
+  const keyMatches = await listObjects(mc, bucket, key);
+  core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
+  if (keyMatches.length > 0) {
+    const exactMatch = keyMatches.find((obj) => obj.name === key)
+    if (exactMatch) {
+      const result = { item: exactMatch, matchingKey: key };
+      core.debug(`Using ${JSON.stringify(result)}`);
+      return result;
+    }
   }
 
   for (const restoreKey of restoreKeys) {
@@ -127,7 +130,7 @@ export async function findObject(
     let objects = await listObjects(mc, bucket, restoreKey);
     objects = objects.filter((o) => o.name.includes(fn));
     core.debug(`Found ${JSON.stringify(objects, null, 2)}`);
-    if (objects.length < 1) {
+    if (objects.length == 0) {
       continue;
     }
     const sorted = objects.sort(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,7 @@ export async function findObject(
   const keyMatches = await listObjects(mc, bucket, key);
   core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
   if (keyMatches.length > 0) {
-    const exactMatch = keyMatches.find((obj) => obj.name === key);
+    const exactMatch = keyMatches.find((obj) => obj.name.startsWith(key));
     if (exactMatch) {
       const result = { item: exactMatch, matchingKey: key };
       core.debug(`Found an exact match; using ${JSON.stringify(result)}`);


### PR DESCRIPTION
<!-- Description of PR that completes issue here... -->

I noticed that exact matching is broken because I was seeing an old cache being restored, which can happen because:

1. [The call to `listObjects()`](https://github.com/tespkg/actions-cache/blob/main/src/utils.ts#L118-L122) can return multiple objects
2. We aren't looking for an exact match
3. We do **not** [sort the return from `listObjects()`](https://github.com/tespkg/actions-cache/blob/main/src/utils.ts#L118-L122)

## Changes

- Make exact matching work as expected: it's exact.

<!-- Example:
- Change 1
- Change 2
- Change 3 - With additional note
-->

## Fix Issues

None, as I worked on the fix before reporting the issue.

<!-- Example:
 - Fixes #85
 - Fixes #22
 - Fixes username/repo#123
 - Connects #123
-->
