### PR TITLE
fix: exact match should check key as path segment

### DIFF
--- a/.github/workflows/test-exact-match.yaml
+++ b/.github/workflows/test-exact-match.yaml
@@ -1,0 +1,73 @@
+name: test-exact-match
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # Save a "decoy" cache whose key is a prefix-extension of the exact key.
+  # e.g. key = "test-exact-Linux-12345-decoy" which shares the prefix
+  # "test-exact-Linux-12345" with the key we'll try to restore later.
+  test-save-decoy:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate decoy cache files
+        shell: bash
+        run: src/create-cache-files.sh ${{ runner.os }} test-cache
+      - name: Save decoy cache
+        uses: ./
+        with:
+          endpoint: ${{ secrets.ENDPOINT }}
+          accessKey: ${{ secrets.ACCESS_KEY }}
+          secretKey: ${{ secrets.SECRET_KEY }}
+          bucket: ${{ secrets.BUCKET }}
+          use-fallback: false
+          key: test-exact-${{ runner.os }}-${{ github.run_id }}-decoy
+          path: test-cache
+
+  # Try to restore with the shorter key that is a prefix of the decoy key.
+  # With correct exact matching this must NOT match the decoy.
+  test-exact-no-false-positive:
+    needs: test-save-decoy
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Restore cache (should miss)
+        id: restore
+        uses: ./
+        with:
+          endpoint: ${{ secrets.ENDPOINT }}
+          accessKey: ${{ secrets.ACCESS_KEY }}
+          secretKey: ${{ secrets.SECRET_KEY }}
+          bucket: ${{ secrets.BUCKET }}
+          use-fallback: false
+          key: test-exact-${{ runner.os }}-${{ github.run_id }}
+          path: test-cache
+      - name: Verify cache was NOT restored
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.restore.outputs.cache-hit }}
+        run: |
+          echo "cache-hit=$CACHE_HIT"
+          if [ "$CACHE_HIT" = "true" ]; then
+            echo "FAIL: cache-hit should not be true — decoy was incorrectly matched"
+            exit 1
+          fi
+          if [ -e test-cache/test-file.txt ]; then
+            echo "FAIL: test-file.txt should not exist — decoy files were restored"
+            exit 1
+          fi
+          echo "PASS: exact match correctly rejected the decoy"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -86300,14 +86300,18 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Key: " + JSON.stringify(key));
         core.debug("Restore keys: " + JSON.stringify(restoreKeys));
-        core.debug(`Finding exact macth for: ${key}`);
-        const exactMatch = yield listObjects(mc, bucket, key);
-        core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
-        if (exactMatch.length) {
-            const result = { item: exactMatch[0], matchingKey: key };
-            core.debug(`Using ${JSON.stringify(result)}`);
-            return result;
+        core.debug(`Finding exact match for: ${key}`);
+        const keyMatches = yield listObjects(mc, bucket, key);
+        core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
+        if (keyMatches.length > 0) {
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            if (exactMatch) {
+                const result = { item: exactMatch, matchingKey: key };
+                core.debug(`Found an exact match; using ${JSON.stringify(result)}`);
+                return result;
+            }
         }
+        core.debug(`Didn't find an exact match`);
         for (const restoreKey of restoreKeys) {
             const fn = utils.getCacheFileName(compressionMethod);
             core.debug(`Finding object with prefix: ${restoreKey}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -86304,7 +86304,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + path_1.default.sep); });
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -86219,7 +86219,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + path_1.default.sep); });
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -86215,14 +86215,18 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Key: " + JSON.stringify(key));
         core.debug("Restore keys: " + JSON.stringify(restoreKeys));
-        core.debug(`Finding exact macth for: ${key}`);
-        const exactMatch = yield listObjects(mc, bucket, key);
-        core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
-        if (exactMatch.length) {
-            const result = { item: exactMatch[0], matchingKey: key };
-            core.debug(`Using ${JSON.stringify(result)}`);
-            return result;
+        core.debug(`Finding exact match for: ${key}`);
+        const keyMatches = yield listObjects(mc, bucket, key);
+        core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
+        if (keyMatches.length > 0) {
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            if (exactMatch) {
+                const result = { item: exactMatch, matchingKey: key };
+                core.debug(`Found an exact match; using ${JSON.stringify(result)}`);
+                return result;
+            }
         }
+        core.debug(`Didn't find an exact match`);
         for (const restoreKey of restoreKeys) {
             const fn = utils.getCacheFileName(compressionMethod);
             core.debug(`Finding object with prefix: ${restoreKey}`);

--- a/dist/saveOnly/index.js
+++ b/dist/saveOnly/index.js
@@ -86219,7 +86219,7 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
         const keyMatches = yield listObjects(mc, bucket, key);
         core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
         if (keyMatches.length > 0) {
-            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + path_1.default.sep); });
             if (exactMatch) {
                 const result = { item: exactMatch, matchingKey: key };
                 core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/dist/saveOnly/index.js
+++ b/dist/saveOnly/index.js
@@ -86215,14 +86215,18 @@ function findObject(mc, bucket, key, restoreKeys, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Key: " + JSON.stringify(key));
         core.debug("Restore keys: " + JSON.stringify(restoreKeys));
-        core.debug(`Finding exact macth for: ${key}`);
-        const exactMatch = yield listObjects(mc, bucket, key);
-        core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
-        if (exactMatch.length) {
-            const result = { item: exactMatch[0], matchingKey: key };
-            core.debug(`Using ${JSON.stringify(result)}`);
-            return result;
+        core.debug(`Finding exact match for: ${key}`);
+        const keyMatches = yield listObjects(mc, bucket, key);
+        core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
+        if (keyMatches.length > 0) {
+            const exactMatch = keyMatches.find((obj) => { var _a; return (_a = obj.name) === null || _a === void 0 ? void 0 : _a.startsWith(key + "/"); });
+            if (exactMatch) {
+                const result = { item: exactMatch, matchingKey: key };
+                core.debug(`Found an exact match; using ${JSON.stringify(result)}`);
+                return result;
+            }
         }
+        core.debug(`Didn't find an exact match`);
         for (const restoreKey of restoreKeys) {
             const fn = utils.getCacheFileName(compressionMethod);
             core.debug(`Finding object with prefix: ${restoreKey}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,7 +132,7 @@ export async function findObject(
   const keyMatches = await listObjects(mc, bucket, key);
   core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
   if (keyMatches.length > 0) {
-    const exactMatch = keyMatches.find((obj) => obj.name?.startsWith(key + "/"));
+    const exactMatch = keyMatches.find((obj) => obj.name?.startsWith(key + path.sep));
     if (exactMatch) {
       const result = { item: exactMatch, matchingKey: key };
       core.debug(`Found an exact match; using ${JSON.stringify(result)}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,14 +128,18 @@ export async function findObject(
   core.debug("Key: " + JSON.stringify(key));
   core.debug("Restore keys: " + JSON.stringify(restoreKeys));
 
-  core.debug(`Finding exact macth for: ${key}`);
-  const exactMatch = await listObjects(mc, bucket, key);
-  core.debug(`Found ${JSON.stringify(exactMatch, null, 2)}`);
-  if (exactMatch.length) {
-    const result = { item: exactMatch[0], matchingKey: key };
-    core.debug(`Using ${JSON.stringify(result)}`);
-    return result;
+  core.debug(`Finding exact match for: ${key}`);
+  const keyMatches = await listObjects(mc, bucket, key);
+  core.debug(`Found ${JSON.stringify(keyMatches, null, 2)}`);
+  if (keyMatches.length > 0) {
+    const exactMatch = keyMatches.find((obj) => obj.name?.startsWith(key + "/"));
+    if (exactMatch) {
+      const result = { item: exactMatch, matchingKey: key };
+      core.debug(`Found an exact match; using ${JSON.stringify(result)}`);
+      return result;
+    }
   }
+  core.debug(`Didn't find an exact match`);
 
   for (const restoreKey of restoreKeys) {
     const fn = utils.getCacheFileName(compressionMethod);


### PR DESCRIPTION
## Summary

- Fixes exact matching in `findObject` — uses `startsWith(key + "/")` instead of `startsWith(key)` to ensure the cache key matches as a full path segment, not just a string prefix
- Addresses the same issue as #60 but with a correct fix (PR #60's `startsWith(key)` still has the prefix-matching bug)
- Adds a CI workflow test that saves a decoy cache with a longer key sharing the same prefix, then verifies exact restore does not match it

## Context

Objects are stored as `{key}/{cacheFileName}` (e.g. `my-cache/cache.tzst`). MinIO's `listObjectsV2` returns all objects with a matching string prefix, so querying `my-cache` also returns `my-cache-v2/cache.tzst`. Checking `startsWith(key + "/")` ensures only objects under the exact key directory match.

## Test plan

- [ ] `test-exact-match` workflow passes — decoy cache is not matched by exact restore
- [ ] Existing `test`, `test-env`, `lookup-only` workflows still pass
- [ ] `build` workflow confirms dist/ is up to date