### PR TITLE
chore: bump node to v24 and update action dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 source_up
-use node 20.19.4
+use node v24

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - name: Install Yarn
         run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/lookup-only.yaml
+++ b/.github/workflows/lookup-only.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate files in working directory
         shell: bash
         run: src/create-cache-files.sh ${{ runner.os }} test-cache
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Lookup cache
         id: lookup
         uses: ./

--- a/.github/workflows/test-env.yaml
+++ b/.github/workflows/test-env.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate files in working directory
         shell: bash
         run: src/create-cache-files.sh ${{ runner.os }} test-cache
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache
         uses: ./
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate files in working directory
         shell: bash
         run: src/create-cache-files.sh ${{ runner.os }} test-cache
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache
         uses: ./
         with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache
         uses: ./
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate files in working directory
         shell: bash
         run: src/create-cache-files.sh ${{ runner.os }} test-cache
@@ -133,7 +133,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache with retry enabled
         uses: ./
         with:
@@ -163,7 +163,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate files in working directory
         shell: bash
         run: src/create-cache-files.sh ${{ runner.os }} test-cache
@@ -192,7 +192,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache
         uses: ./restore/
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This action enables caching dependencies to s3 compatible storage, e.g. minio, AWS S3
 
-It also has github [actions/cache@v2](https://github.com/actions/cache) fallback if s3 save & restore fails
+It also has github [actions/cache@v5](https://github.com/actions/cache) fallback if s3 save & restore fails
 
 ## Usage
 
@@ -114,7 +114,7 @@ To check if cache hits and size is not zero without downloading:
 
 ## Restore keys
 
-`restore-keys` works similar to how github's `@actions/cache@v2` works: It search each item in `restore-keys`
+`restore-keys` works similar to how github's `@actions/cache@v5` works: It search each item in `restore-keys`
 as prefix in object names and use the latest one
 
 ## Amazon S3 permissions

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "s3 cache"
 author: tespkg
-description: "S3 actions cache with actions/cache@v2 passthrough"
+description: "S3 actions cache with actions/cache@v5 passthrough"
 inputs:
   endpoint:
     description: "s3 / minio endpoint, see: https://docs.min.io/docs/javascript-client-api-reference.html"
@@ -66,7 +66,7 @@ outputs:
   cache-size:
     description: "A integer value denoting the size of the cache object found (measured in bytes)"
 runs:
-  using: node20
+  using: node24
   main: "dist/restore/index.js"
   post: "dist/save/index.js"
   post-if: "success()"

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -1,6 +1,6 @@
 name: "s3 cache"
 author: tespkg
-description: "S3 actions cache with actions/cache@v2 passthrough"
+description: "S3 actions cache with actions/cache@v5 passthrough"
 inputs:
   endpoint:
     description: "s3 / minio endpoint, see: https://docs.min.io/docs/javascript-client-api-reference.html"
@@ -66,7 +66,7 @@ outputs:
   cache-size:
     description: "A integer value denoting the size of the cache object found (measured in bytes)"
 runs:
-  using: node20
+  using: node24
   main: "../dist/restore/index.js"
 branding:
   icon: "archive"

--- a/save/action.yml
+++ b/save/action.yml
@@ -1,6 +1,6 @@
 name: "s3 cache"
 author: tespkg
-description: "S3 actions cache with actions/cache@v2 passthrough"
+description: "S3 actions cache with actions/cache@v5 passthrough"
 inputs:
   endpoint:
     description: "s3 / minio endpoint, see: https://docs.min.io/docs/javascript-client-api-reference.html"
@@ -54,7 +54,7 @@ inputs:
   #   required: false
   #   default: -n
 runs:
-  using: node20
+  using: node24
   main: "../dist/saveOnly/index.js"
 branding:
   icon: "archive"


### PR DESCRIPTION
## Summary

- Bump Node.js runtime from 20 to 24 (`.envrc`, `action.yml`, `restore/action.yml`, `save/action.yml`, `build.yaml`)
- Bump `actions/checkout` from v4 to v6 (`build.yaml`, `test.yml`, `lookup-only.yaml`, `test-env.yaml`)
- Bump `actions/setup-node` from v4 to v6 (`build.yaml`)
- Bump `actions/cache` from v3 to v5 (`build.yaml`)
- Update description references from `actions/cache@v2` to `actions/cache@v5` (`action.yml`, `restore/action.yml`, `save/action.yml`, `README.md`)

## Test plan

- [ ] Verify CI build workflow passes with Node.js 24
- [ ] Verify cache save/restore tests pass on all OS matrices
- [ ] Verify lookup-only tests pass
- [ ] Verify env-based auth tests pass