### PR TITLE
ci: automate dist/ build and v1 tag release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,13 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -24,7 +23,7 @@ jobs:
         run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         id: yarn-cache
         with:
@@ -34,14 +33,17 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Deps
         run: yarn install --pure-lockfile
-      # - name: Build & Test
-      #   run: yarn test
-      - name: Ensure dist/ folder is up-to-date
+      - name: Build
+        run: yarn build
+      - name: Commit dist/ changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          yarn build
-          if [ "$(git diff --ignore-space-at-eol | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
-            git diff
-            exit 1
+          git add dist/
+          if git diff --cached --quiet; then
+            echo "dist/ is up to date, nothing to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: update dist/ build artifacts"
+            git push
           fi
-

--- a/.github/workflows/lookup-only.yaml
+++ b/.github/workflows/lookup-only.yaml
@@ -1,13 +1,16 @@
 name: test-lookup-only
 
 on:
-  push:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   test-save:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update major version tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Extract major version (e.g., v1.9.0 -> v1)
+          MAJOR_TAG="${RELEASE_TAG%%.*}"
+          echo "Moving ${MAJOR_TAG} tag to ${RELEASE_TAG}"
+          git tag -fa "${MAJOR_TAG}" -m "${MAJOR_TAG} compatible release"
+          git push -f origin "${MAJOR_TAG}"

--- a/.github/workflows/test-env.yaml
+++ b/.github/workflows/test-env.yaml
@@ -1,13 +1,16 @@
 name: test-env
 
 on:
-  push:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   test-save:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/test-exact-match.yaml
+++ b/.github/workflows/test-exact-match.yaml
@@ -1,7 +1,9 @@
 name: test-exact-match
 
 on:
-  push:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
     branches: [main]
   pull_request:
     branches: [main]
@@ -11,6 +13,7 @@ jobs:
   # e.g. key = "test-exact-Linux-12345-decoy" which shares the prefix
   # "test-exact-Linux-12345" with the key we'll try to restore later.
   test-save-decoy:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,16 @@
 name: test
 
 on:
-  push:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   test-save:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -95,6 +98,7 @@ jobs:
         run: src/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 
   test-save-retry:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -156,6 +160,7 @@ jobs:
         run: src/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 
   test-save-only:
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]


### PR DESCRIPTION
## Summary
- **Issue #20**: Build workflow now auto-commits `dist/` artifacts on push to main — no more manual builds before pushing. On PRs, it just verifies the build succeeds.
- **Issue #21**: New release workflow automatically moves the major version tag (e.g. `v1`) when a `v1.x.y` release is published, replacing the manual `git tag -f` + `git push -f --tags` process.
- Test workflows now trigger via `workflow_run` after build completes on main, ensuring tests always use freshly built artifacts.
- Minor cleanups: fixed deprecated `set-output` syntax, updated `GITHUB_OUTPUT` usage.

Closes #20, closes #21

## Test plan
- [ ] Push a source-only change to main and verify the build workflow auto-commits `dist/`
- [ ] Verify test workflows trigger after build completes (via `workflow_run`)
- [ ] Create a test release and verify the `v1` tag is automatically moved
- [ ] Open a PR and verify the build step runs without auto-committing