### PR TITLE
fix: aws credentials action inputs set to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ jobs:
         with:
           endpoint: play.min.io # optional, default s3.amazonaws.com
           insecure: false # optional, use http instead of https. default false
-          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
-          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # optional
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # optional
           sessionToken: "AQoDYXdzEJraDcqRtz123" # optional
           bucket: actions-cache # required
           use-fallback: true # optional, use github actions cache fallback, default true
@@ -64,8 +64,8 @@ To write to the cache only:
 ```yaml
       - uses: tespkg/actions-cache/save@v1
         with:
-          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
-          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # optional
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # optional
           bucket: actions-cache # required
           # actions/cache compatible properties: https://github.com/actions/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -78,8 +78,8 @@ To restore from the cache only:
 ```yaml
       - uses: tespkg/actions-cache/restore@v1
         with:
-          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
-          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # optional
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # optional
           bucket: actions-cache # required
           # actions/cache compatible properties: https://github.com/actions/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -94,8 +94,8 @@ To check if cache hits and size is not zero without downloading:
         id: cache
         uses: tespkg/actions-cache/check@v1
         with:
-          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
-          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # optional
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # optional
           bucket: actions-cache # required
           lookup-only: true
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -130,8 +130,8 @@ To restore from the cache using a `restore-key` prefix if the `key` restore fail
 ```yaml
       - uses: tespkg/actions-cache/restore@v1
         with:
-          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
-          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # optional
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # optional
           bucket: actions-cache # required
           # actions/cache compatible properties: https://github.com/actions/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
     required: false
   accessKey:
     description: s3 / minio accessKey
-    required: true
+    required: false
   secretKey:
     description: s3 / minio secretKey
-    required: true
+    required: false
   sessionToken:
     description: s3 session token - required when using role
     required: false

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -17,10 +17,10 @@ inputs:
     required: false
   accessKey:
     description: s3 / minio accessKey
-    required: true
+    required: false
   secretKey:
     description: s3 / minio secretKey
-    required: true
+    required: false
   sessionToken:
     description: s3 session token - required when using role
     required: false


### PR DESCRIPTION
This PR set AWS credentials (`accessKey`, `secretKey`) as optional inputs.
I think this should have probably been part of #40.
Having AWS credentials optional results in transparent authentication if used with `aws-actions/configure-aws-credentials`.

## Fix Issues
- avoid ugly workaround, such as `accessKey: false` in action inputs, when using environment variables
