### PR TITLE
feat: add support for `restore-only` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ To restore from the cache only:
             node_modules
 ```
 
+To restore from the cache only (dynamically):
+
+```yaml
+      - uses: tespkg/actions-cache@v1
+        with:
+          accessKey: "Q3AM3UQ867SPQQA43P2F" # required
+          secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG" # required
+          bucket: actions-cache # required
+          restore-only: true
+          # actions/cache compatible properties: https://github.com/actions/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: |
+            node_modules
+```
+
 To check if cache hits and size is not zero without downloading:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "Check if a restore is successfull but dont download/extract cache."
     required: false
     default: "false"
+  restore-only:
+    description: "Restore a cache but don't attempt to save it"
+    required: false
+    default: "false"
   retry:
     description: "Enable retry on failure for S3 operations"
     required: false

--- a/src/save.ts
+++ b/src/save.ts
@@ -1,8 +1,13 @@
 import * as core from "@actions/core";
 import {
+  getInputAsBoolean,
   saveCache,
 } from "./utils";
 
 process.on("uncaughtException", (e) => core.info("warning: " + e.message));
 
-saveCache(false);
+const restoreOnly = getInputAsBoolean("restore-only");
+
+if (!restoreOnly) {
+  saveCache(false);
+}


### PR DESCRIPTION
This PR adds support for a new `restore-only` input to the root `actions-cache`.

The use case for this is similar to `actions-cache/restore`, but where we want to skip the `save` dynamically; for example:
```yaml
- uses: tespkg/actions-cache@v1
  with:
    restore-only: ${{ inputs.skip_cache_save }}
```