### PR TITLE
fix(deps): bump form-data to 2.5.6 (GHSA-hmw2-7cc7-3qxx, High)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,9 +1477,9 @@ for-each@^0.3.5:
     is-callable "^1.2.7"
 
 form-data@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.5.tgz#a5f6364ad7e4e67e95b4a07e2d8c6f711c74f624"
-  integrity sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
Resolves the High-severity Dependabot alert **GHSA-hmw2-7cc7-3qxx** for `form-data`.

`form-data` is pulled in transitively via `@actions/cache → @azure/ms-rest-js` (range `form-data@^2.5.0`). The lockfile resolved it to the vulnerable **2.5.5**; bumped to **2.5.6** (first patched), which satisfies the existing range — no direct dependency or `package.json` change.

Verified locally:
- `yarn install --frozen-lockfile` passes (integrity validated)
- installed `form-data` reports 2.5.6
- `yarn build` passes; bundled `dist/` is unchanged by the bump

The secret-gated test jobs will show red here (Dependabot/fork-style secret limitation); the `build` check is the meaningful one.